### PR TITLE
Add settings module with logo upload

### DIFF
--- a/prisma/migrations/20250612210000_add_setting/migration.sql
+++ b/prisma/migrations/20250612210000_add_setting/migration.sql
@@ -1,0 +1,6 @@
+-- CreateTable
+CREATE TABLE "Setting" (
+    "key" VARCHAR(64) NOT NULL,
+    "value" TEXT,
+    CONSTRAINT "Setting_pkey" PRIMARY KEY ("key")
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -231,3 +231,9 @@ model Collaborator {
 
   @@index([name])
 }
+
+/// Configuraciones globales
+model Setting {
+  key   String @id @db.VarChar(64)
+  value String?
+}

--- a/src/app/(protected)/settings/SettingsClient.tsx
+++ b/src/app/(protected)/settings/SettingsClient.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import Image from "next/image";
+import { useState } from "react";
+import { useDropzone } from "react-dropzone";
+import { Button } from "@/components/ui/button";
+import { uploadLogo } from "./actions";
+import { toast } from "sonner";
+
+export default function SettingsClient({ current }: { current: string }) {
+  const [file, setFile] = useState<File | null>(null);
+  const [preview, setPreview] = useState<string>(current);
+  const { getRootProps, getInputProps, isDragActive } = useDropzone({
+    accept: { "image/*": [".png", ".jpg", ".jpeg"] },
+    maxFiles: 1,
+    onDrop: (files) => {
+      const f = files[0];
+      if (f) {
+        setFile(f);
+        const reader = new FileReader();
+        reader.onload = () => setPreview(reader.result as string);
+        reader.readAsDataURL(f);
+      }
+    },
+  });
+
+  const submit = async () => {
+    if (!file) return;
+    const fd = new FormData();
+    fd.append("file", file);
+    try {
+      const res = await uploadLogo(fd);
+      toast.success("Logo actualizado");
+      setPreview(res.url);
+      setFile(null);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Error");
+    }
+  };
+
+  return (
+    <section className="space-y-6 px-4 md:px-8 py-6">
+      <h1 className="text-3xl font-bold">Configuración</h1>
+
+      <div>
+        <p className="mb-2 text-sm text-muted-foreground">Logo actual</p>
+        <Image src={preview} alt="logo" width={180} height={60} className="border rounded bg-white" />
+      </div>
+
+      <div
+        {...getRootProps()}
+        className={`border-2 border-dashed rounded-md p-6 text-center cursor-pointer ${isDragActive ? "border-primary bg-primary/10" : "border-muted"}`}
+      >
+        <input {...getInputProps()} />
+        {file ? <p>{file.name}</p> : <p>{isDragActive ? "Suelta la imagen" : "Arrastra una imagen o haz clic"}</p>}
+      </div>
+
+      <Button onClick={submit} disabled={!file}>Guardar</Button>
+    </section>
+  );
+}

--- a/src/app/(protected)/settings/actions.ts
+++ b/src/app/(protected)/settings/actions.ts
@@ -1,0 +1,29 @@
+"use server";
+
+import { writeFile, mkdir } from "fs/promises";
+import path from "path";
+import prisma from "@/lib/prisma";
+import { revalidatePath } from "next/cache";
+
+export async function uploadLogo(fd: FormData) {
+  const file = fd.get("file") as File | null;
+  if (!file) throw new Error("Archivo no seleccionado");
+
+  const uploads = path.join(process.cwd(), "public", "assets");
+  await mkdir(uploads, { recursive: true });
+  const ext = path.extname(file.name) || ".png";
+  const filename = "company-logo" + ext.toLowerCase();
+  const buffer = Buffer.from(await file.arrayBuffer());
+  await writeFile(path.join(uploads, filename), buffer);
+
+  const url = `/assets/${filename}`;
+
+  await prisma.setting.upsert({
+    where: { key: "logoUrl" },
+    update: { value: url },
+    create: { key: "logoUrl", value: url },
+  });
+
+  revalidatePath("/settings");
+  return { url };
+}

--- a/src/app/(protected)/settings/page.tsx
+++ b/src/app/(protected)/settings/page.tsx
@@ -1,0 +1,10 @@
+import prisma from "@/lib/prisma";
+import SettingsClient from "./SettingsClient";
+
+export const revalidate = 0;
+
+export default async function SettingsPage() {
+  const setting = await prisma.setting.findUnique({ where: { key: "logoUrl" } });
+  const url = setting?.value || "/next.svg";
+  return <SettingsClient current={url} />;
+}

--- a/src/components/SidebarNav.tsx
+++ b/src/components/SidebarNav.tsx
@@ -10,7 +10,7 @@ import {
   // ClipboardList,
   // FileBarChart2,
   // ShieldCheck,
-  // Settings,
+  Settings,
   RotateCcw,
   SendToBack,
   Users,
@@ -55,12 +55,12 @@ const sections = [
   //     { href: '/audit', label: 'Auditoría', icon: <ShieldCheck size={18} />, description: 'Control y trazabilidad' },
   //   ]
   // },
-  // { 
-  //   title: 'Sistema', 
-  //   items: [
-  //     { href: '/settings', label: 'Configuración', icon: <Settings size={18} />, description: 'Parámetros generales' }
-  //   ] 
-  // },
+  {
+    title: 'Sistema',
+    items: [
+      { href: '/settings', label: 'Configuración', icon: <Settings size={18} />, description: 'Parámetros generales' }
+    ]
+  },
 ];
 
 export default function SidebarNav() {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,0 +1,8 @@
+import prisma from "./prisma";
+import path from "path";
+
+export async function getLogoFilePath() {
+  const setting = await prisma.setting.findUnique({ where: { key: "logoUrl" } });
+  const rel = setting?.value || "assets/company-logo.png";
+  return path.resolve(process.cwd(), "public", rel);
+}

--- a/src/lib/pdf/delivery-batch.ts
+++ b/src/lib/pdf/delivery-batch.ts
@@ -1,6 +1,6 @@
 import { PDFDocument, StandardFonts, rgb } from "pdf-lib";
 import { readFile } from "fs/promises";
-import path from "path";
+import { getLogoFilePath } from "@/lib/config";
 import { DeliveryBatch } from "@prisma/client";
 
 export type DeliveryBatchFull = DeliveryBatch & {
@@ -134,7 +134,7 @@ const logoX = 40;
 const logoY = currentY - headerHeight/2 - logoHeight/2;
 
 try {
-  const logoPath = path.resolve(process.cwd(), 'public', 'assets', 'logo-dimahisac.png');
+  const logoPath = await getLogoFilePath();
   const logoBytes = await readFile(logoPath);
   const logoImage = await pdf.embedPng(logoBytes);
   


### PR DESCRIPTION
## Summary
- introduce `Setting` table via Prisma migration
- add configuration page with logo uploader
- show Settings section in sidebar
- fetch logo path in PDF generation

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_688a33593fa0832ab0e94e0857f5f4a1